### PR TITLE
Add dependent applications to `applications` in .app.src

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -51,8 +51,6 @@
                         , unknown
                         ]}
            , {plt_apps, all_deps}
-             %% Not sure why `proper` is not recognized as a dep
-           , {plt_extra_apps, [proper]}
            ]}.
 
 {xref_checks, [ undefined_function_calls

--- a/src/proper_contrib.app.src
+++ b/src/proper_contrib.app.src
@@ -4,7 +4,8 @@
   {registered, []},
   {applications,
    [kernel,
-    stdlib
+    stdlib,
+    proper
    ]},
   {env,[]},
   {modules, []},


### PR DESCRIPTION
Hi Roberto!

Release scripts and some tools (I think this includes `rebar3 dialyzer`) uses application and included_applications to calculate which applications to work with.